### PR TITLE
dsd: use find -exec instead of xargs

### DIFF
--- a/helpers/copy_system.sh
+++ b/helpers/copy_system.sh
@@ -86,5 +86,5 @@ fi
 # Apply patches if exist
 if [ -d patches ]; then
     echo "Apply patches:"
-    find patches/* | xargs patch -p1 -i
+    find patches/* -exec patch -p1 -i {} +
 fi


### PR DESCRIPTION
Looks cleaner and doesn't break on non alpha-numeric characters.
See: https://github.com/koalaman/shellcheck/wiki/SC2038