### PR TITLE
helpers: separate VINTF object manifest only for device variants

### DIFF
--- a/helpers/copy_vendor.sh
+++ b/helpers/copy_vendor.sh
@@ -80,12 +80,12 @@ if grep -q "%define multiple_rpms 1" "$MODIFY_SPEC"; then
         mkdir -p $DEVICE/vendor
         mv $VENDOR_SPARSE/build.prop $DEVICE/vendor
     fi
-fi
 
-# Move Vendor Interface Object manifest to proper place
-if [ -f $VENDOR_SPARSE/etc/vintf/manifest.xml ]; then
-    mkdir -p $DEVICE/vendor/etc/vintf
-    mv $VENDOR_SPARSE/etc/vintf/manifest.xml $DEVICE/vendor/etc/vintf/manifest.xml
+    # Move Vendor Interface Object manifest to proper place
+    if [ -f $VENDOR_SPARSE/etc/vintf/manifest.xml ]; then
+        mkdir -p $DEVICE/vendor/etc/vintf
+        mv $VENDOR_SPARSE/etc/vintf/manifest.xml $DEVICE/vendor/etc/vintf/manifest.xml
+    fi
 fi
 
 # Apply patches if exist


### PR DESCRIPTION
Currently this manifest will not make it into the image if device does not have separate variant .spec, unlike https://github.com/mer-hybris/droid-vendor-sony-pie-template/blob/5ba6f570021c1a15d47922b7763a453443e34bc6/rpm/droid-system-vendor-kirin-i3113.spec#L36

This PR fixes that.