### PR TITLE
sparse: do not output when chown fails on mountpoints

### DIFF
--- a/helpers/copy_tree.sh
+++ b/helpers/copy_tree.sh
@@ -64,7 +64,7 @@ echo "Copy $TREE_MOUNT/* to $TREE_SPARSE"
 rsync -a --exclude="lost+found" "$TREE_MOUNT"/* "$TREE_SPARSE"
 
 pushd "$TREE_MOUNT" 1>/dev/null || exit
-find . \( -uid +0 -or -gid +0 \) -and \( -type f -or -type d -or -type s \) -printf "[ -e /$TREE/%P ] && chown %U:%G /$TREE/%P\n" 2>/dev/null | LC_ALL="C" sort > "$post_rules"
+find . \( -uid +0 -or -gid +0 \) -and \( -type f -or -type d -or -type s \) -printf "[ -e /$TREE/%P ] && chown %U:%G /$TREE/%P ||:\n" 2>/dev/null | LC_ALL="C" sort > "$post_rules"
 popd 1>/dev/null || exit
 
 if [ "$(wc -l < "$post_rules")" -gt 0 ]; then


### PR DESCRIPTION
RPM installation %post phase warns when trying to chown a directory
that is currently mounted already. E.g.:

chown: /vendor/bt_firmware: Read-only file system
chown: /vendor/firmware_mnt: Read-only file system
warning: %post(droid-system...) scriptlet failed, exit status 1

It's harmless, as the correct ownership is already set during image creation.

The only potential problem would be if ownership should change in the future,
which then could be solved via oneshot before mounts happen.